### PR TITLE
Update git add command in GPTAutoCommitter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -158,6 +158,7 @@ class GPTAutoCommitter {
     }
 
     private async commitChanges(commitMessage: string): Promise<void> {
+        await this.execShellCommand('git add -u');
         await this.execShellCommand(`git commit -m "${commitMessage}"`);
         await this.execShellCommand(`git push origin HEAD ${process.argv.includes('--force') ? '-f' : ''}`);
     }

--- a/index.ts
+++ b/index.ts
@@ -158,7 +158,6 @@ class GPTAutoCommitter {
     }
 
     private async commitChanges(commitMessage: string): Promise<void> {
-        await this.execShellCommand('git add .');
         await this.execShellCommand(`git commit -m "${commitMessage}"`);
         await this.execShellCommand(`git push origin HEAD ${process.argv.includes('--force') ? '-f' : ''}`);
     }


### PR DESCRIPTION
🤖 This PR was initiated by the GPT Auto Committer, an automated tool for managing git commits. You can learn more about it [here](https://github.com/itai-sagi/gpt-auto-committer).

### Description
The update in this PR modifies the 'git add' command in the GPTAutoCommitter class. Previously, the command used was 'git add .' to add all changes to the staging area, but now it has been changed to 'git add -u' to only update the changes which are already being tracked. This change is significant as it affects the way changes are staged for the commit process.

### Impact
This modification ensures that only the tracked changes are added to the staging area, providing more control over the files that are being committed. It aligns with best practices for managing changes in a git repository and reduces the risk of unintentionally staging and committing unnecessary changes.

### Additional Notes
The GPT Auto Committer facilitates smooth collaboration and code management, ensuring that changes are effectively tracked and committed. With this update, the tool becomes even more precise and efficient in managing git commands.