### PR TITLE
GPT Auto Committer: PR Creation and Profile Configuration

### DIFF
--- a/github.ts
+++ b/github.ts
@@ -16,7 +16,6 @@ export class GitHubService {
     private initialized: boolean = false;
 
     constructor(private readonly githubToken: string) {
-        console.log(this.githubToken)
         this.initializeGitInfo()
     }
 

--- a/github.ts
+++ b/github.ts
@@ -16,6 +16,7 @@ export class GitHubService {
     private initialized: boolean = false;
 
     constructor(private readonly githubToken: string) {
+        console.log(this.githubToken)
         this.initializeGitInfo()
     }
 

--- a/github.ts
+++ b/github.ts
@@ -12,15 +12,11 @@ export interface GitInfo {
 }
 
 export class GitHubService {
-    private githubToken: string | undefined = process.env.GITHUB_ACCESS_TOKEN;
     private gitInfo: GitInfo | undefined;
     private initialized: boolean = false;
 
-    constructor() {
-        if (!this.githubToken) {
-            throw new Error('No GitHub access token');
-        }
-        this.initializeGitInfo(); // Initialize gitInfo upon instantiation
+    constructor(private readonly githubToken: string) {
+        this.initializeGitInfo()
     }
 
     private async initializeGitInfo() {

--- a/index.ts
+++ b/index.ts
@@ -160,13 +160,13 @@ class GPTAutoCommitter {
                 return;
             }
 
-            console.log(selectedProfile)
             this.setEnvVariableFromProfile('JIRA_EMAIL', selectedProfile.jiraEmail);
             this.setEnvVariableFromProfile('JIRA_API_KEY', selectedProfile.jiraApiKey);
             this.setEnvVariableFromProfile('JIRA_DOMAIN', selectedProfile.jiraDomain);
             this.setEnvVariableFromProfile('GITHUB_ACCESS_TOKEN', selectedProfile.githubAccessToken);
             this.setEnvVariableFromProfile('OPENAI_API_KEY', selectedProfile.openaiApiKey);
             this.setEnvVariableFromProfile('OPENAI_MODEL', selectedProfile.openaiModel, 'gpt-3.5-turbo-1106');
+            console.log(this.githubToken)
 
             console.log(`Profile configuration for '${profileName}' loaded from ${profilePath}.`);
         } catch (error) {

--- a/index.ts
+++ b/index.ts
@@ -31,7 +31,7 @@ class GPTAutoCommitter {
             throw new Error('No OpenAI API key');
         }
         this.openai = new OpenAI();
-        this.githubService = new GitHubService();
+        this.githubService = new GitHubService(this.githubToken);
         this.templates = {
             prDescription: compileHandlebars(`${__dirname}/prompts/pullRequestDescription.hbs`),
             commitMessage: compileHandlebars(`${__dirname}/prompts/commitMessage.hbs`)
@@ -263,8 +263,10 @@ class GPTAutoCommitter {
         return this.getEnvVariable('JIRA_DOMAIN');
     }
 
-    get githubToken(): string | undefined {
-        return this.getEnvVariable('GITHUB_ACCESS_TOKEN');
+    get githubToken(): string {
+        const token = this.getEnvVariable('GITHUB_ACCESS_TOKEN');
+
+        return token as string;
     }
 
     get model(): string {

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node
+
 import * as child_process from 'child_process';
 import fetch from 'node-fetch';
 import { OpenAI } from 'openai';
@@ -27,6 +29,10 @@ class GPTAutoCommitter {
     };
 
     constructor() {
+        const profileOptionIndex = process.argv.findIndex((arg: string) => arg.startsWith('--profile='));
+        const profileName = profileOptionIndex !== -1 ? process.argv[profileOptionIndex].split('=')[1] : 'default';
+        this.loadProfileFromPath(`${process.env.HOME}/.gac/profile`, profileName);
+
         if (!process.env.OPENAI_API_KEY) {
             throw new Error('No OpenAI API key');
         }
@@ -44,10 +50,7 @@ class GPTAutoCommitter {
         const shouldUpdatePullRequest = process.argv.includes('--update-pr');
         const versionFlagIndex = process.argv.findIndex((arg:string) => arg.startsWith('--version'));
         const branchIndex = process.argv.findIndex((arg:string) => arg.startsWith('--branch='));
-        const profileOptionIndex = process.argv.findIndex((arg: string) => arg.startsWith('--profile='));
-        const profileName = profileOptionIndex !== -1 ? process.argv[profileOptionIndex].split('=')[1] : 'default';
 
-        this.loadProfileFromPath(`${process.env.HOME}/.gac/profile`, profileName);
 
         let versionBump = undefined;
         let newBranch = undefined;
@@ -166,7 +169,6 @@ class GPTAutoCommitter {
             this.setEnvVariableFromProfile('GITHUB_ACCESS_TOKEN', selectedProfile.githubAccessToken);
             this.setEnvVariableFromProfile('OPENAI_API_KEY', selectedProfile.openaiApiKey);
             this.setEnvVariableFromProfile('OPENAI_MODEL', selectedProfile.openaiModel, 'gpt-3.5-turbo-1106');
-            console.log(this.githubToken)
 
             console.log(`Profile configuration for '${profileName}' loaded from ${profilePath}.`);
         } catch (error) {

--- a/index.ts
+++ b/index.ts
@@ -160,6 +160,7 @@ class GPTAutoCommitter {
                 return;
             }
 
+            console.log(selectedProfile)
             this.setEnvVariableFromProfile('JIRA_EMAIL', selectedProfile.jiraEmail);
             this.setEnvVariableFromProfile('JIRA_API_KEY', selectedProfile.jiraApiKey);
             this.setEnvVariableFromProfile('JIRA_DOMAIN', selectedProfile.jiraDomain);

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,9 @@ class GPTAutoCommitter {
     constructor() {
         const profileOptionIndex = process.argv.findIndex((arg: string) => arg.startsWith('--profile='));
         const profileName = profileOptionIndex !== -1 ? process.argv[profileOptionIndex].split('=')[1] : 'default';
+        if (profileName !== 'default') {
+            this.loadProfileFromPath(`${process.env.HOME}/.gac/profile`, 'default');
+        }
         this.loadProfileFromPath(`${process.env.HOME}/.gac/profile`, profileName);
 
         if (!process.env.OPENAI_API_KEY) {

--- a/index.ts
+++ b/index.ts
@@ -51,7 +51,6 @@ class GPTAutoCommitter {
         const versionFlagIndex = process.argv.findIndex((arg:string) => arg.startsWith('--version'));
         const branchIndex = process.argv.findIndex((arg:string) => arg.startsWith('--branch='));
 
-
         let versionBump = undefined;
         let newBranch = undefined;
         if (versionFlagIndex !== -1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-auto-committer",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "dependencies": {
         "axios": "^1.6.5",
         "handlebars": "^4.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-auto-committer",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "dependencies": {
         "axios": "^1.6.5",
         "handlebars": "^4.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "ts-node": "^10.9.2"
       },
       "bin": {
-        "gac": "ts-node ./index.ts"
-      },
-      "devDependencies": {}
+        "gac": "index.ts",
+        "gac-install": "postinstall.js"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-auto-committer",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "dependencies": {
         "axios": "^1.6.5",
         "handlebars": "^4.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-auto-committer",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "dependencies": {
         "axios": "^1.6.5",
         "handlebars": "^4.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-auto-committer",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "dependencies": {
         "axios": "^1.6.5",
         "handlebars": "^4.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.12",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpt-auto-committer",
-      "version": "1.0.12",
+      "version": "1.0.14",
       "dependencies": {
         "axios": "^1.6.5",
         "handlebars": "^4.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "description": "CLI tool for automating commits & GitHub pull requests using LLMs",
   "bin": {
     "gac": "ts-node ./index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "CLI tool for automating commits & GitHub pull requests using LLMs",
   "bin": {
     "gac": "ts-node ./index.ts"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.12",
+  "version": "1.0.14",
   "description": "CLI tool for automating commits & GitHub pull requests using LLMs",
   "bin": {
-    "gac": "ts-node ./index.ts"
+    "gac": "./index.ts"
   },
   "postinstall": "node postinstall.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "CLI tool for automating commits & GitHub pull requests using LLMs",
   "bin": {
     "gac": "ts-node ./index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "CLI tool for automating commits & GitHub pull requests using LLMs",
   "bin": {
     "gac": "./index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpt-auto-committer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "CLI tool for automating commits & GitHub pull requests using LLMs",
   "bin": {
     "gac": "ts-node ./index.ts"

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const gacDirectory = path.join(os.homedir(), '.gac');
+const defaultProfilePath = path.join(gacDirectory, 'profile');
+
+if (!fs.existsSync(gacDirectory)) {
+    fs.mkdirSync(gacDirectory);
+    console.log(`Creating directory: ${gacDirectory}`);
+}
+
+if (!fs.existsSync(defaultProfilePath)) {
+    const defaultProfileContent = `
+    [default]
+    jiraEmail = ${process.env.JIRA_EMAIL || ''}
+    jiraApiKey = ${process.env.JIRA_API_KEY || ''}
+    jiraDomain = ${process.env.JIRA_DOMAIN || ''}
+    githubAccessToken = ${process.env.GITHUB_ACCESS_TOKEN || ''}
+    openaiApiKey = ${process.env.OPENAI_API_KEY || ''}
+    openaiModel = ${process.env.OPENAI_MODEL || 'gpt-3.5-turbo-1106'}
+    `;
+
+    fs.writeFileSync(defaultProfilePath, defaultProfileContent.trim());
+    console.log(`Default profile created at: ${defaultProfilePath}`);
+} else {
+    console.log(`Default profile already exists at: ${defaultProfilePath}`);
+}

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,3 @@ openaiModel = gpt-3.5-turbo-1106
 
 ## Customization
 - Make sure to review and customize Handlebars templates in the `./prompts` directory for commit messages and pull request descriptions.
-
-
-test

--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,15 @@ openaiApiKey = projectX-openai-api-key
 openaiModel = gpt-3.5-turbo-1106
 ```
 ## Usage
+
 ### Running the Script
-1. Run the script using ts-node:
+1. Install GPT-Auto-Commiter:
    ```bash
-   ts-node <path_to_script>/index.ts <Jira_issue_ID> [--update-pr] [--force] [--version=<version>] [--branch=<branch_name>]
+   npm install gpt-auto-committer
+   ```
+2. Run it
+   ```bash
+   npx gac <Jira_issue_ID> [--update-pr] [--force] [--version=<version>] [--branch=<branch_name>]
    ```
   - `<Jira_issue_ID>`: Optional Jira issue ID.
   - `--update-pr`: Flag to create or update a pull request.
@@ -60,7 +65,7 @@ openaiModel = gpt-3.5-turbo-1106
   - --version=<version>: Optional flag to specify the version bump (e.g., --version=patch/minor/major). 
   - --branch=<branch_name>: Optional flag to specify a new branch name. 
   - If on head branch and a jira issue was supplied and no new branch was supplied, a branch will be created in the same name as the jira issue id.
-
+3. Profit!
 
 ## Functionality
 - **Pull Request Updates:** Updates or creates a pull request with generated descriptions based on Git Diff and optional Jira content.

--- a/readme.md
+++ b/readme.md
@@ -68,3 +68,6 @@ openaiModel = gpt-3.5-turbo-1106
 
 ## Customization
 - Make sure to review and customize Handlebars templates in the `./prompts` directory for commit messages and pull request descriptions.
+
+
+test


### PR DESCRIPTION
🎉 This PR introduces several key changes: 
1. **GitHubService Constructor Update**: The GitHubService constructor was updated to accept the `githubToken` as a parameter, ensuring that the GitHub access token is now a required parameter during service initialization. 
2. **Update to index.ts**: The file mode was updated to 100755, and a shebang line `#!/usr/bin/env ts-node` was added, streamlining execution of the script as a command-line utility. 
3. **JiraIssue Interface Addition**: A new interface `JiraIssue` was introduced to represent Jira issue data, including fields for summary and description. 
4. **GPTAutoCommitter Profile Configuration**: A post-install script was added to create a default profile for GPTAutoCommitter, allowing users to configure environmental variables using INI-style profiles at `~/.gac/profile`. 
5. **README.md Update**: The README was updated to include information on setting up profiles via the profile configuration and added a `postinstall` script to create a default profile. 

🤖 This PR was initiated by the GPT Auto Committer. For more information about the GPT Auto Committer, please visit [GPT Auto Committer](https://github.com/itai-sagi/gpt-auto-committer)